### PR TITLE
Add `createBlockNumber`, `createdAt`, and `createTransactionHash` to `EnhancedToken`

### DIFF
--- a/src/resources/schema.graphql
+++ b/src/resources/schema.graphql
@@ -932,6 +932,15 @@ type EnhancedToken {
   """The token ID on CoinMarketCap."""
   cmcId: Int
 
+  """The block height the token was created at."""
+  createBlockNumber: Int
+
+  """The unix timestamp for the creation of the token."""
+  createdAt: Int	
+
+  """The transaction hash of the token's creation."""
+  createTransactionHash: String
+
   """
   The precision to which the token can be divided. For example, the smallest unit for USDC is 0.000001 (6 decimals).
   """


### PR DESCRIPTION
Adding some missing fields related to token creation data that are now supported as per API docs: https://docs.defined.fi/reference/token#enhancedtoken